### PR TITLE
Reusable CI workflow for Django APIs

### DIFF
--- a/.github/workflows/ci-django-api-README.md
+++ b/.github/workflows/ci-django-api-README.md
@@ -1,0 +1,56 @@
+# 🚀 Reusable CI workflow for Django APIs
+
+This reusable workflow is part of the City of Helsinki’s GitHub Actions setup, specifically designed to provide an opinionated and consistent CI process for City of Helsinki’s Django API projects.
+
+## 🌟 Key Features
+
+- **Commit Linting**: Enforces commit message standards using [commitlint](https://commitlint.js.org/).
+- **Code Style Checks**: Verifies code style and formatting using [pre-commit](https://pre-commit.com/).
+- **Automated Testing**: Runs project tests using [pytest](https://docs.pytest.org/en/stable/).
+- **Code Quality Analysis**: Performs a [SonarCloud](https://sonarcloud.io/) scan.
+
+## 📋 Requirements for Projects Using the Workflow
+
+- **commitlint** [config file](https://commitlint.js.org/reference/configuration.html#config-via-file) is present in the root of the project.
+- **pre-commit** is set up with a `.pre-commit-config.yaml` file in the root of the project.
+- **pytest** is used for testing, and tests can be run with `pytest` from the root of the project.
+- **SonarCloud** is configured with `GITHUB_TOKEN` and `SONAR_TOKEN` set in the repository secrets.
+- `requirements.txt` and `requirements-dev.txt` are used for Python dependencies.
+
+## 📚 Usage Instructions
+
+To use this reusable workflow, create a project-specific workflow file in your `.github/workflows` directory. Ensure the `uses` value is set to `City-of-Helsinki/.github/.github/workflows/ci-django-api.yml@main` and `secrets` is set to `inherit`. Also provide the following inputs as needed:
+
+### 🛑 Required Inputs
+
+- **`python-version`** (string): Specifies the Python version to use in the workflow.
+- **`postgres-major-version`** (number): Specifies the PostgreSQL major version (allowed values: `13`, `14`).
+
+### 🔶 Optional Inputs
+
+- **`use-postgis`** (boolean): Set to `true` to enable the PostGIS extension. Default is `false`.
+- **`extra-commands`** (string): Additional setup commands or checks to execute before running tests.
+
+### 📄 Example usage (`<own project>/.github/workflows/ci.yml`)
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  common:
+    uses: City-of-Helsinki/.github/.github/workflows/ci-django-api.yml@main
+    secrets: inherit
+    with:
+      python-version: 3.9
+      postgres-major-version: 14
+      use-postgis: true
+      extra-commands: |
+        echo "EXTRA_TEST_ENV_VAR=test" >> $GITHUB_ENV
+        pip install extra-test-package
+        python manage.py extra_check

--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -1,0 +1,139 @@
+name: Common CI for Django APIs
+on:
+  workflow_call:
+    inputs:
+      # Required parameters
+      python-version:
+        description: 'Python version to use'
+        required: true
+        type: string
+      postgres-major-version:
+        description: 'PostgreSQL major version to use (supported versions are 13 and 14)'
+        required: true
+        type: number
+      # Optional parameters
+      use-postgis:
+        description: 'Set to true to use the PostGIS extension'
+        required: false
+        type: boolean
+        default: false
+      extra-commands:
+        description: 'Extra setup commands or checks to run before running tests'
+        required: false
+        type: string
+  workflow_dispatch:
+
+env:
+  SECRET_KEY: topsecret123
+  DATABASE_URL: ${{ inputs.use-postgis == true && 'postgis' || 'postgres' }}://test_user:test_password@localhost/test_db
+  # Used by django-searchable-encrypted-fields
+  FIELD_ENCRYPTION_KEYS: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+
+jobs:
+  commitlint:
+    name: Check commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@3d28780bbf0365e29b144e272b2121204d5be5f3  # v6.1.2
+
+  pre-commit:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.1
+
+  tests:
+    name: Run tests and SonarCloud scan
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        # The workflow supports only the PostgreSQL and PostGIS versions used in Platta
+        image: ${{ inputs.use-postgis &&
+                    (inputs.postgres-major-version == '14' && 'postgis/postgis:14-3.2-alpine' ||
+                     inputs.postgres-major-version == '13' && 'postgis/postgis:13-3.2-alpine') ||
+                    (inputs.postgres-major-version == '14' && 'postgres:14-alpine' ||
+                     inputs.postgres-major-version == '13' && 'postgres:13-alpine') ||
+                     'postgres:alpine' }}  # This fallback is used only so that we don't error out before the validation step
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        # Needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Validate provided PostgreSQL major version
+        run: |
+          if [[ "${{ inputs.postgres-major-version }}" != "13" && "${{ inputs.postgres-major-version }}" != "14" ]]; then
+            echo "Error: Unsupported PostgreSQL major version provided. Supported versions are 13 and 14."
+            exit 1
+          fi
+      - name: Set up locale
+        run: |
+            sudo locale-gen fi_FI.UTF-8
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Required by SonarCloud
+          fetch-depth: 0
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install libpq-dev gettext
+      - name: Install system packages for PostGIS
+        if: ${{ inputs.use-postgis }}
+        run: |
+          sudo apt-get install gdal-bin
+      - name: Setup Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: pip
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-pip-modules
+        with:
+          path: ~/.pip-cache
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run extra commands
+        if: ${{ inputs.extra-commands != ''}}
+        run: ${{ inputs.extra-commands }}
+      - name: Compile translations
+        run: |
+          if find . -name "*.po" | grep -q .; then
+            python manage.py compilemessages
+          fi
+      - name: Check migrations
+        run: |
+          python manage.py makemigrations --dry-run --check
+      - name: Run tests
+        run: |
+          pytest -ra -vvv --cov=. --cov-report=xml
+      # Without this workaround, SonarCloud reports a warning about an incorrect source path
+      - name: Override coverage report source path for SonarCloud
+        run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This PR includes a new common CI workflow for CoH Django APIs. For details check [the README](https://github.com/City-of-Helsinki/.github/pull/1/files?short_path=c1dc9f8#diff-c1dc9f8cebe6f89fb2673b659a1b6233d660639360f39c52d6f2e3be732e0c70).

Usage examples (WIP PRs):
* [Linked Events](https://github.com/City-of-Helsinki/linkedevents/pull/1010)
* [KerroKantasi](https://github.com/City-of-Helsinki/kerrokantasi/pull/526)
* [ATV](https://github.com/City-of-Helsinki/atv/pull/114)

Things to still figure out:
* versioning. It would be nice if this workflow could use semantic versioning to properly handle breaking changes. Need for other tags in this repo can make that more difficult.

Refs [RAT-212](https://helsinkisolutionoffice.atlassian.net/browse/RAT-212)

[RAT-212]: https://helsinkisolutionoffice.atlassian.net/browse/RAT-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ