### PR TITLE
Switch CI-workflows to use active SonarQube cloud action

### DIFF
--- a/.github/workflows/ci-django-api-README.md
+++ b/.github/workflows/ci-django-api-README.md
@@ -7,14 +7,14 @@ This reusable workflow is part of the City of Helsinki’s GitHub Actions setup,
 - **Commit Linting**: Enforces commit message standards using [commitlint](https://commitlint.js.org/).
 - **Code Style Checks**: Verifies code style and formatting using [pre-commit](https://pre-commit.com/).
 - **Automated Testing**: Runs project tests using [pytest](https://docs.pytest.org/en/stable/).
-- **Code Quality Analysis**: Performs a [SonarCloud](https://sonarcloud.io/) scan.
+- **Code Quality Analysis**: Performs a [SonarQube Cloud](https://sonarcloud.io/) scan.
 
 ## 📋 Requirements for Projects Using the Workflow
 
 - **commitlint** [config file](https://commitlint.js.org/reference/configuration.html#config-via-file) is present in the root of the project.
 - **pre-commit** is set up with a `.pre-commit-config.yaml` file in the root of the project.
 - **pytest** is used for testing, and tests can be run with `pytest` from the root of the project.
-- **SonarCloud** is configured with `SONAR_TOKEN` set in the repository secrets.
+- **SonarQube Cloud** is configured with `SONAR_TOKEN` set in the repository secrets.
 - `requirements.txt` and `requirements-dev.txt` are used for Python dependencies.
 
 ## 📚 Usage Instructions

--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -53,7 +53,7 @@ jobs:
       uses: pre-commit/action@v3.0.1
 
   tests:
-    name: Run tests and SonarCloud scan
+    name: Run tests and SonarQube Cloud scan
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Required by SonarCloud
+          # Required by SonarQube Cloud
           fetch-depth: 0
       - name: Install system packages
         run: |
@@ -129,10 +129,10 @@ jobs:
       - name: Run tests
         run: |
           pytest -ra -vvv --cov=. --cov-report=xml
-      # Without this workaround, SonarCloud reports a warning about an incorrect source path
-      - name: Override coverage report source path for SonarCloud
+      # Without this workaround, SonarQube Cloud reports a warning about an incorrect source path
+      - name: Override coverage report source path for SonarQube Cloud
         run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
-      - name: SonarCloud Scan
+      - name: SonarQube Cloud Scan
         uses: SonarSource/sonarqube-scan-action@v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Override coverage report source path for SonarCloud
         run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-node-README.md
+++ b/.github/workflows/ci-node-README.md
@@ -7,12 +7,12 @@ This reusable workflow is part of the City of Helsinki’s GitHub Actions setup,
 - **Commit Linting**: Enforces commit message standards using [commitlint](https://commitlint.js.org/).
 - **Build and Lint**: Build and verifies code style and formatting via yarn.
 - **Automated Testing**: Runs project tests via yarn.
-- **Code Quality Analysis**: Performs a [SonarCloud](https://sonarcloud.io/) scan.
+- **Code Quality Analysis**: Performs a [SonarQube Cloud](https://sonarcloud.io/) scan.
 
 ## 📋 Requirements for Projects Using the Workflow
 
 - **commitlint** [config file](https://commitlint.js.org/reference/configuration.html#config-via-file) is present in the root of the project.
-- **SonarCloud** is configured with `SONAR_TOKEN` set in the repository or organization secrets.
+- **SonarQube Cloud** is configured with `SONAR_TOKEN` set in the repository or organization secrets.
 
 ### 🧶 Yarn Commands
 

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -55,7 +55,7 @@ jobs:
       env:
         CI: true
 
-    - name: SonarCloud Scan
+    - name: SonarQube Cloud Scan
       uses: SonarSource/sonarqube-scan-action@v5.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -56,7 +56,7 @@ jobs:
         CI: true
 
     - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@v5.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Switched the common Django and Node CI workflows to use the active SonarQube Cloud action as the previously used one was deprecated. Also updated "SonarCloud" to "SonarQube Cloud" to reflect the service's name change.

Tested with https://github.com/City-of-Helsinki/haravajarjestelma/pull/185

Refs: RATYK-96