### PR TITLE
chore: update sonarcube action version to 6

### DIFF
--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Override coverage report source path for SonarQube Cloud
         run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
       - name: SonarQube Cloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -108,7 +108,7 @@ jobs:
         CI: true
 
     - name: SonarQube Cloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5
+      uses: SonarSource/sonarqube-scan-action@v6
       with:
         projectBaseDir: ${{ inputs.app-directory }}
       env:


### PR DESCRIPTION
Update sonarcube scan action version from 5 to 6.

This PR seems to work ok with this change:
https://github.com/City-of-Helsinki/servicemap-ui/pull/1275