### PR TITLE
chore: tweak sync commit message

### DIFF
--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -23,4 +23,4 @@ jobs:
           GH_INSTALLATION_TOKEN: ${{ steps.app-token.outputs.token}}
           GIT_EMAIL: sync.bot@example.com
           GIT_USERNAME: github-sync[bot]
-          COMMIT_PREFIX: "chore: file sync update\n\nSigned-off-by: sol-office-file-synchronization[bot]\n\n"
+          COMMIT_PREFIX: "chore: file sync update\n\nSigned-off-by: sol-office-file-synchronization[bot]\n\nSync:"


### PR DESCRIPTION
Whitespace gets stripped away from the end of the given message, so add "Sync:" to the last line to ensure that the sync information actually ends up on its own line.