### PR TITLE
feat: add option to skip build in node

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip-build:
+        description: 'Set to true to skip the build phase'
+        required: false
+        type: boolean
+        default: false
       working-directory:
         description: 'Working directory for the yarn installation, build and tests jobs.'
         required: false
@@ -50,6 +55,7 @@ jobs:
 
   build:
     name: Lint and build
+    if: ${{ !inputs.skip-build }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Add option to skip the build phase in node version.
Makes it possible to use this ci flow with shared parts in the yjdh monorepo.

btw. seems that some of the options are kebab case and some are snake case. I made this in kebab because those seem to be majority. 

Related to this PR: https://github.com/City-of-Helsinki/yjdh/pull/3778