### PR TITLE
ci: separate sonarcloud job from unit tests

### DIFF
--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -58,7 +58,7 @@ jobs:
       uses: pre-commit/action@v3.0.1
 
   tests:
-    name: Run tests and SonarQube Cloud scan
+    name: Run tests
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -144,13 +144,31 @@ jobs:
       - name: Run tests
         run: |
           pytest -ra -vvv --cov=. --cov-report=xml
-      # Without this workaround, SonarQube Cloud reports a warning about an incorrect source path
-      - name: Override coverage report source path for SonarQube Cloud
-        run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
-      - name: SonarQube Cloud Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+      - name: Store coverage.xml
+        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
         with:
-          projectBaseDir: ${{ inputs.working-directory }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          path: coverage.xml
+          key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+
+  sonarcloud:
+    name: Run SonarQube Cloud Scan
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+    - uses: actions/checkout@v4
+    - name: Restore coverage.xml
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
+      with:
+        path: coverage.xml
+        key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+        fail-on-cache-miss: true
+    # Without this workaround, SonarQube Cloud reports a warning about an incorrect source path
+    - name: Override coverage report source path for SonarQube Cloud
+      run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
+    - name: SonarQube Cloud Scan
+      uses: SonarSource/sonarqube-scan-action@v6
+      with:
+        projectBaseDir: ${{ inputs.working-directory }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Done in a similar way as in https://github.com/City-of-Helsinki/django-logger-extra/pull/20

Refs: RAT-357