### PR TITLE
fix(ci-django-api): include working-directory in coverage cache path

### DIFF
--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -147,19 +147,23 @@ jobs:
       - name: Store coverage.xml
         uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
         with:
-          path: coverage.xml
+          path: ${{ inputs.working-directory && format('{0}/', inputs.working-directory) || ''}}coverage.xml
           key: cache-${{ github.run_id }}-${{ github.run_attempt }}
 
   sonarcloud:
     name: Run SonarQube Cloud Scan
     runs-on: ubuntu-latest
     needs: tests
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+
     steps:
     - uses: actions/checkout@v4
     - name: Restore coverage.xml
       uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
       with:
-        path: coverage.xml
+        path: ${{ inputs.working-directory && format('{0}/', inputs.working-directory) || ''}}coverage.xml
         key: cache-${{ github.run_id }}-${{ github.run_attempt }}
         fail-on-cache-miss: true
     # Without this workaround, SonarQube Cloud reports a warning about an incorrect source path


### PR DESCRIPTION
The change implemented in #24 doesn't work when using the `working-directory` input (cannot find coverage.xml because coverage.xml is located under `working-directory`).

This fix includes `working-directory` in the cache path.

Tested in https://github.com/City-of-Helsinki/unified-search/pull/241

Refs: RAT-362
