### PR TITLE
feat: move sonar to separate job RAT-358

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -135,8 +135,6 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Use Node.js ${{ inputs.node-version }} with dependency path
       if: ${{ inputs.working-directory != '.' }}
       uses: actions/setup-node@v4

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -171,6 +171,9 @@ jobs:
       run: yarn test:coverage
       env:
         CI: true
+    # Coverage path logic (keep in sync with sonarcloud job's cache/restore step):
+    # Resolves the effective directory (app-directory if set, else working-directory),
+    # then prefixes 'coverage' with '<dir>/' when running in a subdirectory.
     - name: Store coverage report
       uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
       with:
@@ -189,6 +192,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    # Coverage path logic (keep in sync with tests job's cache/save step):
+    # Resolves the effective directory (app-directory if set, else working-directory),
+    # then prefixes 'coverage' with '<dir>/' when running in a subdirectory.
     - name: Restore coverage report
       uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
       with:

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -135,6 +135,8 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Use Node.js ${{ inputs.node-version }} with dependency path
       if: ${{ inputs.working-directory != '.' }}
       uses: actions/setup-node@v4
@@ -171,9 +173,37 @@ jobs:
       run: yarn test:coverage
       env:
         CI: true
+    - name: Store coverage report
+      uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
+      with:
+        path: ${{ (inputs.app-directory == '.' && inputs.working-directory || inputs.app-directory) && format('{0}/', inputs.app-directory == '.' && inputs.working-directory || inputs.app-directory) || ''}}coverage
+        key: cache-${{ github.run_id }}-${{ github.run_attempt }}
 
+  sonarcloud:
+    name: Run SonarQube Cloud Scan
+    if: ${{ !inputs.skip_sonar }}
+    runs-on: ubuntu-latest
+    needs: tests
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Restore coverage report
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
+      with:
+        path: ${{ (inputs.app-directory == '.' && inputs.working-directory || inputs.app-directory) && format('{0}/', inputs.app-directory == '.' && inputs.working-directory || inputs.app-directory) || ''}}coverage
+        key: cache-${{ github.run_id }}-${{ github.run_attempt }}
+        fail-on-cache-miss: true
+    # Without this workaround, SonarQube Cloud reports a warning about an incorrect source path
+    - name: Override coverage report source path for SonarQube Cloud
+      working-directory: ${{ inputs.app-directory == '.' && inputs.working-directory || inputs.app-directory }}
+      run: |
+        find coverage -type f \( -name '*.info' -o -name 'lcov.info' \) 2>/dev/null | xargs -r sed -i 's@SF:'$GITHUB_WORKSPACE'@SF:/github/workspace/@g' || true
+        find coverage -type f -name '*.json' 2>/dev/null | xargs -r sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' || true
     - name: SonarQube Cloud Scan
-      if: ${{ !inputs.skip_sonar }}
       uses: SonarSource/sonarqube-scan-action@v6
       with:
         projectBaseDir: ${{ inputs.app-directory == '.' && inputs.working-directory || inputs.app-directory }}


### PR DESCRIPTION
Move sonarcoud to a separate job.

Refs: RAT-358 https://helsinkisolutionoffice.atlassian.net/browse/RAT-358

Similar change done to backend: https://github.com/City-of-Helsinki/.github/pull/24

There are two PR:s where I used a copy of this .yml to test that sonar is run and uses the coverage info.
These have in purpose new functios that don't have 100% test coverage. I will delete these later.
https://github.com/City-of-Helsinki/open-city-profile-ui/pull/492
https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/561