### PR TITLE
Fix problems with sonar scan in django api

### DIFF
--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -172,9 +172,6 @@ jobs:
         path: ${{ inputs.working-directory && format('{0}/', inputs.working-directory) || ''}}coverage.xml
         key: cache-${{ github.run_id }}-${{ github.run_attempt }}
         fail-on-cache-miss: true
-    # Without this workaround, SonarQube Cloud reports a warning about an incorrect source path
-    - name: Override coverage report source path for SonarQube Cloud
-      run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
     - name: SonarQube Cloud Scan
       uses: SonarSource/sonarqube-scan-action@v6
       with:

--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -177,5 +177,4 @@ jobs:
       with:
         projectBaseDir: ${{ inputs.working-directory }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -106,8 +106,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Required by SonarQube Cloud
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Install system packages
         run: |
           sudo apt-get update
@@ -166,6 +165,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      # Required by SonarQube Cloud for blame information
+      with:
+        fetch-depth: 0
     - name: Restore coverage.xml
       uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb  # v5.0.1
       with:


### PR DESCRIPTION
1) sed is no longer seemingly needed
2) GITHUB_TOKEN is not needed
3) fetch depth 0 needs to be in the job that runs sonar scan, because sonar scan collects the blame information (it is not part of the coverage report)

smbackend runs this this PR branch in main and it has no more warnings: https://sonarcloud.io/project/overview?id=City-of-Helsinki_smbackend

You can compare to linkedevents, which has warnings: https://sonarcloud.io/project/overview?id=City-of-Helsinki_linkedevents

<img width="922" height="454" alt="image" src="https://github.com/user-attachments/assets/3bdec444-93bc-4a09-8dd7-e6fe42b5025e" />
