### PR TITLE
chore: bump commitlint version

### DIFF
--- a/.github/workflows/ci-django-api.yml
+++ b/.github/workflows/ci-django-api.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run commitlint
-        uses: wagoid/commitlint-github-action@3d28780bbf0365e29b144e272b2121204d5be5f3  # v6.1.2
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed  # v6.2.1
 
   pre-commit:
     name: Run pre-commit hooks

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run commitlint
-        uses: wagoid/commitlint-github-action@3d28780bbf0365e29b144e272b2121204d5be5f3  # v6.1.2
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed  # v6.2.1
 
   build:
     name: Lint and build


### PR DESCRIPTION
Use the same version of commitlint in all workflows.