### PR TITLE
feat: add postgres option for ci-python-library

### DIFF
--- a/.github/workflows/ci-python-library-README.md
+++ b/.github/workflows/ci-python-library-README.md
@@ -7,6 +7,7 @@ This reusable workflow is part of the City of Helsinki's GitHub Actions setup, s
 - **Commit Linting**: Enforces commit message standards using [commitlint](https://commitlint.js.org/).
 - **Code Style Checks**: Verifies code style and formatting using [pre-commit](https://pre-commit.com/).
 - **Automated Testing**: Runs project tests across multiple Python versions using [hatch](https://hatch.pypa.io/).
+- **Database Testing**: Optionally starts a PostgreSQL (with or without PostGIS) service and sets `DATABASE_URL` for tests that require a database.
 - **Code Quality Analysis**: Performs a [SonarQube Cloud](https://sonarcloud.io/) scan.
 
 ## Requirements for Projects Using the Workflow
@@ -30,6 +31,8 @@ To use this reusable workflow, create a project-specific workflow file in your `
 - **`enable-sonar`** (boolean): Whether to run the SonarQube Cloud Scan job after tests. Defaults to `true`.
 - **`commitlint-config-file`** (string): Path to the commitlint config file. If not set, commitlint uses its default config discovery.
 - **`pre-commit-config-file`** (string): Path to `.pre-commit-config.yaml`. If empty, pre-commit uses its default discovery (file in repository root).
+- **`postgres-major-version`** (string): PostgreSQL major version to use for testing. Supported versions: `13`, `14`, `17`. Optional - omit if no database is needed.
+- **`use-postgis`** (boolean): Set to `true` to use the PostGIS extension. Requires `postgres-major-version` to be set. Defaults to `false`.
 
 ### Secrets
 
@@ -61,3 +64,32 @@ jobs:
     with:
       python-matrix: "['3.10', '3.11', '3.12', '3.13', '3.14']"
 ```
+
+### Example usage with PostgreSQL (`<own project>/.github/workflows/ci.yml`)
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  common:
+    uses: City-of-Helsinki/.github/.github/workflows/ci-python-library.yml@main
+    secrets:
+      sonar-token: ${{ secrets.SONAR_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      python-matrix: "['3.12', '3.13']"
+      postgres-major-version: "17"
+```
+
+When `postgres-major-version` is set, the workflow starts a PostgreSQL service and exposes a `DATABASE_URL` environment variable (`postgres://test_user:test_password@localhost/test_db`) to the test runner.

--- a/.github/workflows/ci-python-library-README.md
+++ b/.github/workflows/ci-python-library-README.md
@@ -31,7 +31,7 @@ To use this reusable workflow, create a project-specific workflow file in your `
 - **`enable-sonar`** (boolean): Whether to run the SonarQube Cloud Scan job after tests. Defaults to `true`.
 - **`commitlint-config-file`** (string): Path to the commitlint config file. If not set, commitlint uses its default config discovery.
 - **`pre-commit-config-file`** (string): Path to `.pre-commit-config.yaml`. If empty, pre-commit uses its default discovery (file in repository root).
-- **`postgres-major-version`** (string): PostgreSQL major version to use for testing. Supported versions: `13`, `14`, `17`. Optional - omit if no database is needed.
+- **`postgres-major-version`** (string): PostgreSQL major version to use for testing. Supported versions: `14`, `17`. Optional - omit if no database is needed.
 - **`use-postgis`** (boolean): Set to `true` to use the PostGIS extension. Requires `postgres-major-version` to be set. Defaults to `false`.
 
 ### Secrets
@@ -92,4 +92,4 @@ jobs:
       postgres-major-version: "17"
 ```
 
-When `postgres-major-version` is set, the workflow starts a PostgreSQL service and exposes a `DATABASE_URL` environment variable (`postgres://test_user:test_password@localhost/test_db`) to the test runner.
+When `postgres-major-version` is set, the workflow starts a PostgreSQL service and exposes a `DATABASE_URL` environment variable (`postgres://test_user:test_password@localhost/test_db`, or `postgis://test_user:test_password@localhost/test_db` when `use-postgis` is `true`) to the test runner.

--- a/.github/workflows/ci-python-library.yml
+++ b/.github/workflows/ci-python-library.yml
@@ -137,6 +137,8 @@ jobs:
         exit 1
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/ci-python-library.yml
+++ b/.github/workflows/ci-python-library.yml
@@ -91,24 +91,6 @@ jobs:
       matrix:
         python_version: ${{ fromJSON(inputs.python-matrix) }}
 
-    services:
-      postgres:
-        # The workflow supports only the PostgreSQL and PostGIS versions used in Platta
-        image: ${{ inputs.postgres-major-version != '' &&
-                  (inputs.use-postgis &&
-                    (inputs.postgres-major-version == '17' && 'postgis/postgis:17-3.5-alpine' ||
-                     inputs.postgres-major-version == '14' && 'postgis/postgis:14-3.2-alpine') ||
-                    (inputs.postgres-major-version == '17' && 'postgres:17-alpine' ||
-                     inputs.postgres-major-version == '14' && 'postgres:14-alpine')) ||
-                  'postgres:alpine' }}  # This fallback is used only so that we don't error out before the validation step
-        env:
-          POSTGRES_USER: test_user
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_DB: test_db
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
     - name: Validate provided PostgreSQL major version
       if: ${{ inputs.postgres-major-version != '' }}
@@ -120,6 +102,39 @@ jobs:
           echo "Error: Unsupported PostgreSQL major version provided. Supported versions are 14 and 17."
           exit 1
         fi
+
+    - name: Start PostgreSQL
+      if: ${{ inputs.postgres-major-version != '' }}
+      env:
+        # The workflow supports only the PostgreSQL and PostGIS versions used in Platta
+        POSTGRES_IMAGE: ${{ inputs.use-postgis &&
+                  (inputs.postgres-major-version == '17' && 'postgis/postgis:17-3.5-alpine' ||
+                   inputs.postgres-major-version == '14' && 'postgis/postgis:14-3.2-alpine') ||
+                  (inputs.postgres-major-version == '17' && 'postgres:17-alpine' ||
+                   inputs.postgres-major-version == '14' && 'postgres:14-alpine') }}
+      run: |
+        docker run -d --name postgres \
+          -e POSTGRES_USER=test_user \
+          -e POSTGRES_PASSWORD=test_password \
+          -e POSTGRES_DB=test_db \
+          -p 5432:5432 \
+          --health-cmd pg_isready \
+          --health-interval 10s \
+          --health-timeout 5s \
+          --health-retries 5 \
+          "$POSTGRES_IMAGE"
+        echo "Waiting for PostgreSQL to become healthy..."
+        for _ in $(seq 1 30); do
+          status=$(docker inspect --format '{{.State.Health.Status}}' postgres)
+          if [[ "$status" == "healthy" ]]; then
+            echo "PostgreSQL is healthy."
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Error: PostgreSQL did not become healthy in time."
+        docker logs postgres
+        exit 1
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/ci-python-library.yml
+++ b/.github/workflows/ci-python-library.yml
@@ -27,6 +27,16 @@ on:
           required: false
           type: string
           default: ''
+      postgres-major-version:
+          description: "PostgreSQL major version to use for testing (supported: 14, 17). Optional - omit if no database is needed."
+          required: false
+          type: string
+          default: ''
+      use-postgis:
+          description: "Set to true to use the PostGIS extension. Requires postgres-major-version to be set."
+          required: false
+          type: boolean
+          default: false
     secrets:
       sonar-token:
         description: "Token for SonarQube Cloud Scan. Required if enable-sonar is set to true."
@@ -81,10 +91,37 @@ jobs:
       matrix:
         python_version: ${{ fromJSON(inputs.python-matrix) }}
 
+    services:
+      postgres:
+        # The workflow supports only the PostgreSQL and PostGIS versions used in Platta
+        image: ${{ inputs.postgres-major-version != '' &&
+                  (inputs.use-postgis &&
+                    (inputs.postgres-major-version == '17' && 'postgis/postgis:17-3.5-alpine' ||
+                     inputs.postgres-major-version == '14' && 'postgis/postgis:14-3.2-alpine') ||
+                    (inputs.postgres-major-version == '17' && 'postgres:17-alpine' ||
+                     inputs.postgres-major-version == '14' && 'postgres:14-alpine')) ||
+                  'postgres:alpine' }}  # This fallback is used only so that we don't error out before the validation step
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
+    - name: Validate provided PostgreSQL major version
+      if: ${{ inputs.postgres-major-version != '' }}
+      env:
+        POSTGRES_MAJOR_VERSION: ${{ inputs.postgres-major-version }}
+      run: |
+        supported_versions=("14" "17")
+        if [[ ! " ${supported_versions[*]} " == *" ${POSTGRES_MAJOR_VERSION} "* ]]; then
+          echo "Error: Unsupported PostgreSQL major version provided. Supported versions are 14 and 17."
+          exit 1
+        fi
+
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python_version }}
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -102,6 +139,22 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
+    - name: Install system packages
+      if: ${{ inputs.postgres-major-version != '' }}
+      env:
+        USE_POSTGIS: ${{ inputs.use-postgis }}
+      run: |
+        packages=(libpq-dev)
+        if [[ "${USE_POSTGIS}" == "true" ]]; then
+          packages+=(gdal-bin)
+        fi
+        sudo apt-get update
+        sudo apt-get install -y "${packages[@]}"
+
+    - name: Set database URL
+      if: ${{ inputs.postgres-major-version != '' }}
+      run: echo "DATABASE_URL=${{ inputs.use-postgis == true && 'postgis' || 'postgres' }}://test_user:test_password@localhost/test_db" >> $GITHUB_ENV
 
     - name: Install hatch
       run: python -m pip install hatch


### PR DESCRIPTION
Refs: RATY-348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Extended reusable CI documentation to support optional PostgreSQL-backed testing, including a PostGIS toggle, new inputs (`postgres-major-version`, `use-postgis`), and example usage.
  * Clarified that `DATABASE_URL` is provided to the test runner when database testing is enabled.

* **Chores**
  * Updated the CI workflow to optionally provision a local PostgreSQL container for database-dependent tests, with PostGIS support when enabled, including version validation and container readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->