### PR TITLE
Add fixed time for Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Helsinki"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Refs: RATY-350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated update schedule to run weekly on Monday at 05:00 Europe/Helsinki time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->