### PR TITLE
chore: change deps review to fail on moderate

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -255,7 +255,7 @@ jobs:
 
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          fail-on-severity: low
+          fail-on-severity: moderate
           fail-on-scopes: runtime, development, unknown
           license-check: false
           vulnerability-check: true

--- a/.github/workflows/ci-pnpm-node.yml
+++ b/.github/workflows/ci-pnpm-node.yml
@@ -265,7 +265,7 @@ jobs:
 
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          fail-on-severity: low
+          fail-on-severity: moderate
           fail-on-scopes: runtime, development, unknown
           license-check: false
           vulnerability-check: true


### PR DESCRIPTION
The previous `fail-on-severity: low` was a bit too aggressive -> `moderate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency checks so the build only fails for moderate or higher-severity issues, reducing unnecessary failures from lower-severity alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->