### PR TITLE
fix: ignore .venv from compilemessages-command

### DIFF
--- a/.github/workflows/ci-uv-django-api.yml
+++ b/.github/workflows/ci-uv-django-api.yml
@@ -157,8 +157,8 @@ jobs:
         run: ${{ inputs.extra-commands }}
       - name: Compile translations
         run: |
-          if find . -name "*.po" | grep -q .; then
-            uv run python manage.py compilemessages
+          if [ -n "$(find . -not \( -name .venv -prune \) -name '*.po' -print -quit)" ]; then
+            uv run python manage.py compilemessages --ignore .venv
           fi
       - name: Check migrations
         run: |


### PR DESCRIPTION
Compilemessages by default will try to compile also other packages messages from venv-folder, which is redundant and might also lead to failures in some scenarios.

Therefore ignore it completely from the command when `.po`-files are not found.

Refs: [RATY-326](https://helsinkisolutionoffice.atlassian.net/browse/RATY-326)

[RATY-326]: https://helsinkisolutionoffice.atlassian.net/browse/RATY-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved translation compilation during automated test runs by excluding the virtual environment directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->