### PR TITLE
chore: remove kerrokantasi from pip dependabot sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -21,7 +21,6 @@ group:
   # backend, pip
   - repos: |
       City-of-Helsinki/example-backend-profile
-      City-of-Helsinki/kerrokantasi
     files: 
       - source: sync/.commitlintrc.mjs
         dest: .commitlintrc.mjs


### PR DESCRIPTION
kerrokantasi has migrated to uv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository synchronization configuration by removing one repository from the backend and pip sync group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->