### PR TITLE
chore(sync): add pypi-publish.yml for python libraries

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -18,6 +18,20 @@ group:
       - source: sync/CODEOWNERS-ratkaisutoimiston-backend
         dest: CODEOWNERS
 
+  # python libraries, publish.yml
+  # this is separated from above since trusted publishing
+  # hasn't been configured for every library yet
+  - repos: |
+      City-of-Helsinki/django-helsinki-suomifi-messages
+      City-of-Helsinki/django-helsinki-suomifi-on-behalf
+      City-of-Helsinki/django-resilient-logger
+      City-of-Helsinki/django-helsinki-health-endpoints
+      City-of-Helsinki/django-helusers
+      City-of-Helsinki/django-logger-extra
+    files: 
+      - source: sync/.github/workflows/pypi-publish.yml
+        dest: .github/workflows/publish.yml
+
   # backend, pip
   - repos: |
       City-of-Helsinki/example-backend-profile

--- a/.github/workflows/build-python-dists-README.md
+++ b/.github/workflows/build-python-dists-README.md
@@ -63,84 +63,11 @@ jobs:
 > publishing part in particular **must** be non-reusable.
 > [See gh-action-pypi-publish's README for more information.](gh-action-pypi-publish#trusted-publishing)
 
-This example also adds a `workflow_dispatch` trigger with the following inputs, allowing the release and publish steps to be run manually for a specific ref:
+For a complete release and publish workflow, refer to [pypi-publish.yml](../../sync/.github/workflows/pypi-publish.yml). It adds a `workflow_dispatch` trigger with the following inputs, allowing the release and publish steps to be run manually for a specific ref:
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `ref` | The branch, tag or SHA to publish. E.g. main, refs/tags/v1.0.0, aeb2839. | Yes | - |
 | `skip-build` | Skip artifact build and publish, i.e. run release-please only. | No | `false` |
-
-```yaml
-name: Create release & publish to PyPI
-# For manual runs:
-# - If ref is set (for example, "refs/tags/v1.2.3"), use "Publish refs/tags/v1.2.3".
-# - If skipping build (for example, ref is "main"), use "Release-please only (main)"
-# Otherwise, use the default name (latest commit).
-run-name: >-
-  ${{
-    inputs.ref &&
-      (inputs.skip-build
-        && format('Release-please only ({0})', inputs.ref)
-        || format('Publish {0}', inputs.ref))
-    || null
-  }}
-
-on:
-  push:
-    branches:
-      - main
-  # Run daily to keep the release PR date current
-  schedule:
-    - cron: '1 0 * * *'
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: "The branch, tag or SHA to publish. E.g. main, refs/tags/v1.0.0, aeb2839."
-        required: true
-        type: string
-      skip-build:
-        description: "Skip artifact build and publish, i.e. run release-please only."
-        default: false
-        type: boolean
-
-jobs:
-  release-please:
-    uses: City-of-Helsinki/.github/.github/workflows/release-please.yml@main
-    permissions:
-      contents: write
-      pull-requests: write
-    with:
-        include-component-in-tag: false
-
-  build:
-    needs:
-      - release-please
-    uses: City-of-Helsinki/.github/.github/workflows/build-python-dists.yml@main
-    with:
-        ref: ${{ inputs.ref }}
-    # If the build is not skipped, run the build job when a release was created or a ref was specified.
-    if: ${{ !inputs.skip-build && (needs.release-please.outputs.release_created || inputs.ref) }}
-
-  publish-to-pypi:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    # Run publish job if an artifact was uploaded
-    if: ${{ needs.build.outputs.artifact_name }}
-    environment:
-      name: pypi
-      url: https://pypi.org/p/<package-name>
-    permissions:
-      id-token: write  # mandatory for trusted publishing
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-      with:
-        name: ${{ needs.build.outputs.artifact_name }}
-        path: dist/
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-```
 
 [gh-action-pypi-publish#trusted-publishing]: https://github.com/pypa/gh-action-pypi-publish/blob/987f11e872eb5ca67aad6a4fe531bd3089142c60/README.md#trusted-publishing

--- a/sync/.github/workflows/pypi-publish.yml
+++ b/sync/.github/workflows/pypi-publish.yml
@@ -1,0 +1,71 @@
+# This file is synced from City-of-Helsinki/.github and should not be edited directly
+name: Create release & publish to PyPI
+# For manual runs:
+# - If ref is set (for example, "refs/tags/v1.2.3"), use "Publish refs/tags/v1.2.3".
+# - If skipping build (for example, ref is "main"), use "Release-please only (main)"
+# Otherwise, use the default name (latest commit).
+run-name: >-
+  ${{
+    inputs.ref &&
+      (inputs.skip-build
+        && format('Release-please only ({0})', inputs.ref)
+        || format('Publish {0}', inputs.ref))
+    || null
+  }}
+
+on:
+  push:
+    branches:
+      - main
+  # Run daily to keep the release PR date current
+  schedule:
+    - cron: '1 0 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to publish. E.g. main, refs/tags/v1.0.0, aeb2839."
+        required: true
+        type: string
+      skip-build:
+        description: "Skip artifact build and publish, i.e. run release-please only."
+        default: false
+        type: boolean
+
+jobs:
+  release-please:
+    uses: City-of-Helsinki/.github/.github/workflows/release-please.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      include-component-in-tag: false
+
+  build:
+    needs:
+      - release-please
+    uses: City-of-Helsinki/.github/.github/workflows/build-python-dists.yml@main
+    with:
+      ref: ${{ inputs.ref }}
+    # If the build is not skipped, run the build job when a release was created or a ref was specified.
+    if: ${{ !inputs.skip-build && (needs.release-please.outputs.release_created || inputs.ref) }}
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    # Run publish job if an artifact was uploaded
+    if: ${{ needs.build.outputs.artifact_name }}
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ github.event.repository.name }}
+    permissions:
+      id-token: write  # mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
Add only for libraries that have trusted publishing configured.

Workflow tested in django-helsinki-suomifi-on-behalf: https://github.com/City-of-Helsinki/django-helsinki-suomifi-on-behalf/actions/runs/30805651454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a standardized PyPI publishing workflow for Python libraries.
  * Supports scheduled, push-based, and manual releases.
  * Manual runs can select a branch, tag, or commit and optionally skip building and publishing.
  * Added trusted publishing of Python distribution artifacts to PyPI.
  * Extended the workflow to additional Python libraries.

* **Documentation**
  * Updated workflow documentation to reference the shared publishing workflow and describe its manual inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->